### PR TITLE
Fix Maven coordinates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use Spine Reflect in your Gradle project:
 
 ```kotlin
 dependencies {
-    implementation("io.spine.tools:spine-reflect:${version}")
+    implementation("io.spine:spine-reflect:$version")
 }
 ```
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-reflect:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine:spine-reflect:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -689,4 +689,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 18 17:13:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 19 20:16:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>reflect</artifactId>
-<version>2.0.0-SNAPSHOT.180</version>
+<version>2.0.0-SNAPSHOT.181</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,4 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.181")
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+// Do not add prefix `spine-` for this single-module project. It will be added automatically.
+rootProject.name = "reflect"


### PR DESCRIPTION
This PR fixes the sample code of adding `spine-reflect` to a Gradle project. The artifact belongs to the `io.spine` group (not `io.spine.tools.` group).
