### PR TITLE
Improve obtaining arguments in generic classes

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-reflect:2.0.0-SNAPSHOT.187`
+# Dependencies of `io.spine:spine-reflect:2.0.0-SNAPSHOT.188`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -832,4 +832,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 02 14:54:18 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 18:30:43 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>reflect</artifactId>
-<version>2.0.0-SNAPSHOT.187</version>
+<version>2.0.0-SNAPSHOT.188</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/java/io/spine/reflect/GenericTypeIndex.java
+++ b/src/main/java/io/spine/reflect/GenericTypeIndex.java
@@ -70,7 +70,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public interface GenericTypeIndex<C> {
 
     /**
-     * Obtains a zero-based index of a generic parameter of a type.
+     * Obtains a zero-based index of the generic type parameter.
      */
     int index();
 
@@ -80,7 +80,7 @@ public interface GenericTypeIndex<C> {
      * @param cls
      *         the class to inspect
      * @return the argument class
-     * @implNote Obtain the super class of the passed one by inspecting the class which
+     * @implNote Obtain the superclass of the passed one by inspecting the class which
      *         implements {@code GenericTypeIndex}.
      */
     default Class<?> argumentIn(Class<? extends C> cls) {
@@ -88,8 +88,8 @@ public interface GenericTypeIndex<C> {
         var indexClass = getClass();
         @SuppressWarnings("unchecked") /* The type cast is ensured by the declaration of
             the `GenericTypeIndex` interface. */
-        var superclassOfPassed = (Class<C>) Types.argumentIn(indexClass, GenericTypeIndex.class, 0);
-        var result = Types.argumentIn(cls, superclassOfPassed, index());
+        var superclassOfPassed = (Class<C>) Types.argumentIn(indexClass, 0, GenericTypeIndex.class);
+        var result = Types.argumentIn(cls, index(), superclassOfPassed);
         return result;
     }
 }

--- a/src/main/java/io/spine/reflect/Types.java
+++ b/src/main/java/io/spine/reflect/Types.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
@@ -162,22 +163,30 @@ public final class Types {
      * Obtains the class of a generic type argument which is specified in the inheritance chain
      * of the passed class.
      *
-     * @param cls
-     *         the end class for which we find the generic argument
-     * @param genericSuperclass
-     *         the superclass of the passed which has generic parameters
-     * @param argNumber
-     *         the index of the generic parameter in the superclass
      * @param <T>
      *         the type of superclass
+     * @param cls
+     *         the end class for which we find the generic argument
+     * @param argNumber
+     *         the index of the generic parameter in the superclass
+     * @param genericSuperclass
+     *         the superclass of the passed which has generic parameters
      * @return the class of the generic type argument
      */
-    static
-    <T> Class<?> argumentIn(Class<? extends T> cls, Class<T> genericSuperclass, int argNumber) {
+    public static
+    <T> Class<?> argumentIn(Class<? extends T> cls, int argNumber, Class<T> genericSuperclass) {
         checkNotNull(cls);
         checkNotNull(genericSuperclass);
         var supertypeToken = TypeToken.of(cls).getSupertype(genericSuperclass);
         var typeArgs = resolveArguments(supertypeToken.getType());
+        checkArgument(
+                argNumber >= 0, "The argument number must be a positive value. Got: %s.", argNumber
+        );
+        checkArgument(
+                argNumber < typeArgs.size(),
+                "The generic supertype `%s` has only %s arguments. Got: %s.",
+                genericSuperclass.getName(), typeArgs.size(), argNumber
+        );
         var argValue = typeArgs.get(argNumber);
         var result = TypeToken.of(argValue).getRawType();
         return result;

--- a/src/main/kotlin/io/spine/reflect/ClassExts.kt
+++ b/src/main/kotlin/io/spine/reflect/ClassExts.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.reflect
+
+/**
+ * Obtains the class of a generic type argument which is specified in the inheritance chain
+ * of the passed class.
+ *
+ * @receiver the end class for which we find the generic argument.
+ * @param [T] the type of superclass.
+ * @param argNumber the index of the generic parameter in the superclass.
+ * @return the class of the generic type argument
+ */
+public inline fun <reified T : Any> Class<out T>.argumentIn(argNumber: Int): Class<*> =
+    Types.argumentIn(this, argNumber, T::class.java)

--- a/src/test/java/io/spine/reflect/TypesTest.java
+++ b/src/test/java/io/spine/reflect/TypesTest.java
@@ -45,6 +45,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.reflect.Types.argumentIn;
 import static io.spine.reflect.Types.isEnumClass;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"SerializableNonStaticInnerClassWithoutSerialVersionUID",
         "SerializableInnerClassWithNonSerializableOuterClass"}) // OK when using TypeToken.
@@ -101,7 +102,7 @@ class TypesTest extends UtilityClassTest<Types> {
         @Test
         @DisplayName("from the inheritance chain")
         void getTypeArgument() {
-            var argument = argumentIn(ListOfMessages.class, Iterable.class, 0);
+            var argument = argumentIn(ListOfMessages.class, 0, Iterable.class);
             assertEquals(argument, Message.class);
         }
 
@@ -109,15 +110,31 @@ class TypesTest extends UtilityClassTest<Types> {
         @DisplayName("assuming generic superclass")
         void assumingGenericSuperclass() {
             var val = new Parametrized<Long, String>() {};
-            assertEquals(Long.class, argumentIn(val.getClass(), Base.class, 0));
-            assertEquals(String.class, argumentIn(val.getClass(), Base.class, 1));
+            assertEquals(Long.class, argumentIn(val.getClass(), 0, Base.class));
+            assertEquals(String.class, argumentIn(val.getClass(), 1, Base.class));
         }
 
         @Test
         @DisplayName("obtain generic argument via superclass")
         void viaSuperclass() {
-            assertEquals(String.class, argumentIn(Leaf.class, Base.class, 0));
-            assertEquals(Float.class, argumentIn(Leaf.class, Base.class, 1));
+            assertEquals(String.class, argumentIn(Leaf.class, 0, Base.class));
+            assertEquals(Float.class, argumentIn(Leaf.class, 1, Base.class));
+        }
+
+        @Test
+        @DisplayName("prohibiting negative argument index")
+        void negativeIndex() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    argumentIn(Leaf.class, -1, Base.class)
+            );
+        }
+
+        @Test
+        @DisplayName("checking that index is within the range of type parameters")
+        void outOfBoundsIndex() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    argumentIn(Leaf.class, 2, Base.class)
+            );
         }
     }
 

--- a/src/test/kotlin/io/spine/reflect/ClassExtsSpec.kt
+++ b/src/test/kotlin/io/spine/reflect/ClassExtsSpec.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.reflect
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Class` extensions should")
+internal class ClassExtsSpec {
+
+    @Test
+    fun `obtain generic type argument`() {
+        Leaf::class.java.argumentIn<Base<*, *>>(0) shouldBe String::class.java
+        Leaf::class.java.argumentIn<Base<*, *>>(1) shouldBe java.lang.Float::class.java
+    }
+}
+
+@Suppress("unused")
+private open class Base<T, K>
+
+private class Leaf : Base<String, Float>()
+

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.187")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.188")


### PR DESCRIPTION
This PR makes it easier to obtain a generic type argument in both Java and Kotlin code.

## Changes in details
 * The method called `argumentIn()` of the Java utility class `Types` was made public. Previously it was package-private. 
 * The order of parameters of the method was improved to 1) match the name 2) reduce the change of accidental misplacement of `Class` arguments.
 * The extension function called `argumentIn()` for `Class` was added to make it more natural when working from Kotlin.
